### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+PinBoard is a zero-dependency static website (HTML/CSS/JS) with two pages: a Pinterest-style image gallery (`index.html`) and a calculator (`calculadora.html`). There is also a standalone Python CLI calculator (`calculadora.py`). All JS/CSS dependencies are loaded from CDNs at runtime; there is no `package.json`, no build step, and no backend.
+
+### Running the app
+
+Serve the repository root with any static HTTP server:
+
+```
+python3 -m http.server 8080 --directory /workspace
+```
+
+Then open `http://localhost:8080/index.html` (gallery) or `http://localhost:8080/calculadora.html` (calculator).
+
+### Running the Python CLI calculator
+
+```
+python3 calculadora.py <operacao> <num1> <num2>
+```
+
+Operations: `soma`, `subtrai`, `multiplica`, `divide`.
+
+### Linting / testing
+
+There is no linting or test framework configured. Validation is manual via browser interaction and running `calculadora.py` from the command line.
+
+### Notes
+
+- All images and third-party libraries (Bootstrap, Masonry, Ionicons, Google Fonts) are fetched from external CDNs. Internet access is required for full rendering.
+- State (theme preference, calculator history) is persisted in `localStorage`.
+- The GitHub Actions workflow (`.github/workflows/calculadora.yml`) references a Windows-specific absolute path and would fail in CI; this is a pre-existing issue in the repo.

--- a/style.css
+++ b/style.css
@@ -482,6 +482,7 @@ body.banner-visible {
   opacity: 0;
   transition: opacity var(--transition-fast);
   z-index: 2;
+  pointer-events: none;
 }
 
 .pin-img-wrap:hover .pin-overlay {
@@ -502,6 +503,7 @@ body.banner-visible {
   justify-content: center;
   transition: background var(--transition-fast), transform var(--transition-fast);
   cursor: pointer;
+  pointer-events: auto;
 }
 
 .pin-action:hover {

--- a/style.css
+++ b/style.css
@@ -482,7 +482,6 @@ body.banner-visible {
   opacity: 0;
   transition: opacity var(--transition-fast);
   z-index: 2;
-  pointer-events: none;
 }
 
 .pin-img-wrap:hover .pin-overlay {
@@ -503,7 +502,6 @@ body.banner-visible {
   justify-content: center;
   transition: background var(--transition-fast), transform var(--transition-fast);
   cursor: pointer;
-  pointer-events: auto;
 }
 
 .pin-action:hover {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for this static website project.

### What's included

- **`AGENTS.md`**: Documents how to serve the app locally, run the Python CLI calculator, and notes about the project (CDN dependencies, no build step, localStorage state, pre-existing CI issue).

### Development environment verified

| Service | Command | Status |
|---------|---------|--------|
| Static HTTP server | `python3 -m http.server 8080` | Working |
| Gallery page | `http://localhost:8080/index.html` | Working (masonry layout, category filters, dark mode) |
| Calculator page | `http://localhost:8080/calculadora.html` | Working (arithmetic operations, history) |
| Python CLI calculator | `python3 calculadora.py soma 5 3` | Working |

### Demo

Gallery page with image filtering and calculator with 7x6=42 computation were tested end-to-end in the browser.

[pinboard_gallery_and_calculator_demo.mp4](https://cursor.com/agents/bc-369e8036-47d6-4f3c-ac50-2be93b0d0b7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpinboard_gallery_and_calculator_demo.mp4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-369e8036-47d6-4f3c-ac50-2be93b0d0b7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-369e8036-47d6-4f3c-ac50-2be93b0d0b7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

